### PR TITLE
Build the junction curation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 __pycache__/
 *.pyc
+curation/

--- a/tools/curate/README.md
+++ b/tools/curate/README.md
@@ -1,0 +1,83 @@
+# Junction curation tool
+
+[#14](https://github.com/jacobemerick/mazatzalhiking/issues/14). Local authoring only —
+this does not ship with the site and has no bearing on the deployed Worker, which still
+serves nothing but `public/`.
+
+```
+./tools/curate/server.py      # then open http://localhost:8723
+```
+
+Python stdlib plus Leaflet from a CDN. No install step, no build.
+
+## Why this runs before the pipeline is finished
+
+#14 asks for "cleaned canonical lines," which #10, #11 and #13 have not produced yet. It
+does not have to wait, because of how the schema splits authored truth from derived data:
+**node coordinates are authored, segment geometry is derived.** A junction placed against a
+raw recorded track stays in exactly the right place when cleaning and traversal-merging
+later change the lines underneath — only the derived geometry is recomputed.
+
+So the durable output of curation is node positions, which nodes connect to which, and
+what the legs are called. None of that is invalidated by the pipeline landing afterwards.
+The distances and elevation figures written today *are* provisional, and will be recomputed
+from the canonical lines once #13 exists.
+
+## Using it
+
+| | |
+|---|---|
+| <kbd>N</kbd> | place a junction — click near a track |
+| <kbd>S</kbd> | make a segment — click one junction, then another |
+| <kbd>Esc</kbd> | back to panning, or dismiss the form |
+| <kbd>⌘Z</kbd> | undo |
+
+**Clicks snap to the recorded tread.** A click within 60 m moves onto the nearest recorded
+point; further out it is refused rather than inventing a junction in open country. The form
+then shows which tracks pass through and on what dates, which is usually how you recognise
+what junction you are looking at.
+
+**Segments trace along a real recorded track.** Picking two junctions finds the tracks that
+pass through both and follows one between them, so a leg's geometry is ground you actually
+walked rather than a straight line. Where several trips cover the stretch, the form lets you
+choose which one to trace, and the chosen track is recorded in the segment's `sources`.
+
+Distance and elevation come from the traced points. Gain uses the direction-symmetric
+algorithm the schema prescribes — simplify the profile, then sum — so reversing a segment
+swaps gain and loss exactly.
+
+Everything saves after every change, so a sitting can be abandoned and resumed. Writes are
+atomic: an interrupted save cannot truncate the work.
+
+## Output
+
+```
+curation/
+  graph.json          nodes, segments, trails — schema-valid, no point data
+  geometry/<id>.json  one file per segment
+```
+
+`curation/` is gitignored while the pass is in progress. Committing the finished graph is
+[#15](https://github.com/jacobemerick/mazatzalhiking/issues/15)'s business, which is also
+where the real judgment happens — what counts as a junction worth modelling. A wash crossing
+is not one; a trail you could actually turn onto is.
+
+Check the output at any point with:
+
+```
+./tools/validate_graph.py curation/graph.json
+```
+
+## Known limits
+
+- **A segment needs one recorded track running through both its junctions.** Where no single
+  trip covers the stretch, the tool says so and asks for an intermediate junction. Stitching
+  a leg across two trips is not supported yet; whether that is worth building depends on how
+  often it comes up in practice.
+- **Features (springs, cabins, camps) cannot be placed yet.** The schema supports them and
+  the builder will show them, but the UI covers junctions and segments first, since those are
+  what the network is made of.
+- **No editing or deletion.** Undo covers mistakes made in a sitting; correcting an earlier
+  sitting means editing `curation/graph.json` by hand for now. Worth adding if it becomes
+  annoying — and note the schema's rule that re-splitting a leg retires its id rather than
+  reusing it.

--- a/tools/curate/index.html
+++ b/tools/curate/index.html
@@ -1,0 +1,328 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Mazatzal junction curation</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin:0; font:13px/1.45 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
+         display:flex; height:100vh; overflow:hidden; color:#1a1a1a; }
+  #map { flex:1; }
+  #side { width:340px; border-left:1px solid #d4d4d4; background:#fafafa;
+          display:flex; flex-direction:column; overflow:hidden; }
+  #side h1 { font-size:13px; margin:0; padding:10px 12px; background:#2c3e34; color:#fff;
+             font-weight:600; letter-spacing:.02em; }
+  .pad { padding:10px 12px; border-bottom:1px solid #e4e4e4; }
+  .mode { display:flex; gap:6px; }
+  .mode button { flex:1; padding:7px 4px; border:1px solid #bbb; background:#fff; cursor:pointer;
+                 border-radius:3px; font:inherit; font-size:12px; }
+  .mode button.on { background:#2c3e34; color:#fff; border-color:#2c3e34; }
+  kbd { background:#eee; border:1px solid #ccc; border-bottom-width:2px; border-radius:3px;
+        padding:0 4px; font:11px ui-monospace,monospace; }
+  #status { font-size:12px; color:#555; min-height:32px; padding:8px 12px; background:#f0efe9;
+            border-bottom:1px solid #e4e4e4; }
+  #status.act { background:#fff6d9; color:#7a5c00; }
+  #status.err { background:#ffe8e8; color:#a11; }
+  #lists { flex:1; overflow-y:auto; }
+  .grp { padding:8px 12px; border-bottom:1px solid #e4e4e4; }
+  .grp h2 { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#666;
+            margin:0 0 6px; font-weight:600; }
+  .row { display:flex; justify-content:space-between; gap:6px; padding:3px 4px; cursor:pointer;
+         border-radius:3px; align-items:baseline; }
+  .row:hover { background:#e8ece9; }
+  .row code { font:11px ui-monospace,monospace; color:#888; }
+  .row .nm { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .row .mi { color:#777; font-size:11px; font-variant-numeric:tabular-nums; }
+  .empty { color:#999; font-style:italic; font-size:12px; }
+  #form { position:absolute; z-index:1000; background:#fff; border:1px solid #999; padding:12px;
+          border-radius:5px; box-shadow:0 6px 24px rgba(0,0,0,.25); width:290px; display:none; }
+  #form label { display:block; font-size:11px; text-transform:uppercase; letter-spacing:.05em;
+                color:#666; margin:8px 0 3px; font-weight:600; }
+  #form input, #form select { width:100%; padding:5px 6px; border:1px solid #bbb; border-radius:3px;
+                              font:inherit; }
+  #form .btns { margin-top:11px; display:flex; gap:6px; }
+  #form button { flex:1; padding:6px; border:1px solid #bbb; background:#fff; border-radius:3px;
+                 cursor:pointer; font:inherit; }
+  #form button.pri { background:#2c3e34; color:#fff; border-color:#2c3e34; }
+  #meta { font-size:11px; color:#666; margin-top:8px; line-height:1.5; }
+  .chk { display:flex; align-items:center; gap:6px; font-size:12px; margin:3px 0; }
+  .trailrow { display:flex; gap:4px; align-items:center; margin:2px 0; font-size:12px; }
+  .trailrow code { color:#888; font:11px ui-monospace,monospace; }
+  .sv { font-size:11px; color:#777; padding:6px 12px; background:#f0efe9; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div id="side">
+  <h1>Junction curation</h1>
+  <div id="status">Loading corpus…</div>
+  <div class="pad">
+    <div class="mode">
+      <button id="mPan"  class="on">Pan <kbd>Esc</kbd></button>
+      <button id="mNode">Node <kbd>N</kbd></button>
+      <button id="mSeg">Segment <kbd>S</kbd></button>
+    </div>
+    <div style="margin-top:9px">
+      <label class="chk"><input type="checkbox" id="showCorpus" checked> recorded tracks</label>
+      <label class="chk"><input type="checkbox" id="showUncurated"> dim curated stretches</label>
+    </div>
+  </div>
+  <div id="lists">
+    <div class="grp"><h2>Trails</h2><div id="trails"></div>
+      <button id="addTrail" style="margin-top:6px;padding:4px 8px;font:inherit;font-size:12px;
+        border:1px solid #bbb;background:#fff;border-radius:3px;cursor:pointer">+ trail</button></div>
+    <div class="grp"><h2>Nodes <span id="nc"></span></h2><div id="nodes"></div></div>
+    <div class="grp"><h2>Segments <span id="sc"></span></h2><div id="segs"></div></div>
+  </div>
+  <div class="sv" id="saved">—</div>
+</div>
+<div id="form"></div>
+
+<script>
+const $ = s => document.querySelector(s);
+let G = {version:1, trails:[], nodes:[], segments:[], features:[], retired:[]};
+let mode = 'pan', pending = null, history = [];
+const map = L.map('map', {preferCanvas:true}).setView([34.05,-111.55], 11);
+
+L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+  {maxZoom:17, attribution:'OpenTopoMap'}).addTo(map);
+
+const corpusLayer = L.layerGroup().addTo(map);
+const graphLayer  = L.layerGroup().addTo(map);
+
+const status = (m, cls='') => { const s=$('#status'); s.textContent=m; s.className=cls; };
+
+// ---------------------------------------------------------------- loading --
+async function boot() {
+  const [corpus, graph] = await Promise.all([
+    fetch('/api/corpus').then(r=>r.json()),
+    fetch('/api/graph').then(r=>r.json()),
+  ]);
+  G = Object.assign({trails:[],nodes:[],segments:[],features:[],retired:[]}, graph);
+  L.geoJSON(corpus, {
+    style: {color:'#c0603a', weight:1.6, opacity:.55},
+    onEachFeature: (f,l) => l.bindTooltip(`${f.properties.trip} · ${f.properties.date} · ${f.properties.miles} mi`)
+  }).addTo(corpusLayer);
+  const b = L.geoJSON(corpus).getBounds();
+  if (b.isValid()) map.fitBounds(b, {padding:[20,20]});
+  redraw();
+  status(`${corpus.features.length} tracks loaded. N to place a junction, S to make a segment.`);
+}
+
+// ------------------------------------------------------------------ state --
+function snapshot() { history.push(JSON.stringify(G)); if (history.length>60) history.shift(); }
+function undo() {
+  if (!history.length) return status('nothing to undo');
+  G = JSON.parse(history.pop()); redraw(); save(); status('undone');
+}
+async function save() {
+  await fetch('/api/graph', {method:'POST', headers:{'Content-Type':'application/json'},
+                             body: JSON.stringify(G)});
+  $('#saved').textContent = `saved ${new Date().toLocaleTimeString()} · curation/graph.json`;
+}
+const mint = kind => fetch('/api/mint', {method:'POST', headers:{'Content-Type':'application/json'},
+  body: JSON.stringify({kind})}).then(r=>r.json()).then(d=>d.id);
+
+// ------------------------------------------------------------------- draw --
+function redraw() {
+  graphLayer.clearLayers();
+  const nodeById = Object.fromEntries(G.nodes.map(n=>[n.id,n]));
+
+  for (const s of G.segments) {
+    if (!s._geo) continue;
+    L.polyline(s._geo.map(c=>[c[1],c[0]]), {color:'#1d6fa5', weight:4, opacity:.85})
+      .bindTooltip(`<b>${s.name}</b><br>${s.miles} mi · +${s.gain_ft}/−${s.loss_ft} ft`)
+      .addTo(graphLayer);
+  }
+  for (const n of G.nodes) {
+    const th = n.kind === 'trailhead';
+    L.circleMarker([n.lat,n.lon], {radius: th?7:5.5, color:'#fff', weight:2,
+      fillColor: th?'#c9a227':'#1a7a3c', fillOpacity:1})
+      .bindTooltip(`<b>${n.name}</b><br>${n.kind} · ${n.id}`)
+      .on('click', e => { L.DomEvent.stop(e); pickNode(n); })
+      .addTo(graphLayer);
+  }
+  if (pending && pending.a) {
+    const a = nodeById[pending.a];
+    if (a) L.circleMarker([a.lat,a.lon], {radius:11, color:'#e08a00', weight:3, fill:false})
+      .addTo(graphLayer);
+  }
+
+  $('#nc').textContent = `(${G.nodes.length})`;
+  $('#sc').textContent = `(${G.segments.length})`;
+  const mi = G.segments.reduce((t,s)=>t+(s.miles||0),0);
+  $('#nodes').innerHTML = G.nodes.length ? G.nodes.map(n=>
+    `<div class="row" data-n="${n.id}"><code>${n.id}</code><span class="nm">${esc(n.name)}</span>
+     <span class="mi">${n.kind==='trailhead'?'TH':'jct'}</span></div>`).join('')
+    : '<div class="empty">none yet</div>';
+  $('#segs').innerHTML = G.segments.length ? G.segments.map(s=>
+    `<div class="row" data-s="${s.id}"><code>${s.id}</code><span class="nm">${esc(s.name)}</span>
+     <span class="mi">${s.miles} mi</span></div>`).join('')
+    + `<div class="row" style="border-top:1px solid #ddd;margin-top:4px;padding-top:5px">
+       <span class="nm"><b>total</b></span><span class="mi"><b>${mi.toFixed(1)} mi</b></span></div>`
+    : '<div class="empty">none yet</div>';
+  $('#trails').innerHTML = G.trails.length ? G.trails.map(t=>
+    `<div class="trailrow"><code>${t.id}</code> ${esc(t.name)}
+     ${t.code?`<span style="color:#999">${esc(t.code)}</span>`:''}
+     <span style="color:#aaa">${t.kind}</span></div>`).join('')
+    : '<div class="empty">none yet</div>';
+
+  document.querySelectorAll('[data-n]').forEach(el => el.onclick = () => {
+    const n = G.nodes.find(x=>x.id===el.dataset.n); map.panTo([n.lat,n.lon]);
+  });
+  document.querySelectorAll('[data-s]').forEach(el => el.onclick = () => {
+    const s = G.segments.find(x=>x.id===el.dataset.s);
+    if (s && s._geo) map.fitBounds(L.polyline(s._geo.map(c=>[c[1],c[0]])).getBounds(),{padding:[40,40]});
+  });
+}
+const esc = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+// ------------------------------------------------------------------- form --
+function form(html, onOk, at) {
+  const f = $('#form');
+  f.innerHTML = html + `<div class="btns"><button class="pri" id="fOk">Save</button>
+                        <button id="fNo">Cancel</button></div>`;
+  f.style.display = 'block';
+  const pt = at || map.latLngToContainerPoint(map.getCenter());
+  f.style.left = Math.min(pt.x + 14, window.innerWidth - 660) + 'px';
+  f.style.top  = Math.min(pt.y, window.innerHeight - 300) + 'px';
+  const first = f.querySelector('input,select'); if (first) { first.focus(); first.select?.(); }
+  const close = () => { f.style.display='none'; pending=null; redraw(); };
+  $('#fNo').onclick = close;
+  $('#fOk').onclick = async () => { const r = await onOk(); if (r !== false) close(); };
+  f.onkeydown = e => {
+    if (e.key === 'Enter') { e.preventDefault(); $('#fOk').click(); }
+    if (e.key === 'Escape') { e.preventDefault(); close(); }
+  };
+}
+
+// ------------------------------------------------------------- placing -----
+map.on('click', async e => {
+  if (mode === 'node') await placeNode(e);
+  else if (mode === 'seg') status('click a junction, not the map — segments run node to node','act');
+});
+
+async function placeNode(e) {
+  status('snapping…');
+  const s = await fetch(`/api/snap?lat=${e.latlng.lat}&lon=${e.latlng.lng}`).then(r=>r.json());
+  if (!s.lat) return status('no track within 60 m — junctions sit on recorded tread','err');
+  status(`snapped ${s.dist.toFixed(0)} m onto ${s.trip}`);
+  const through = await fetch(`/api/through?lat=${s.lat}&lon=${s.lon}`).then(r=>r.json());
+  form(`<label>Junction name</label><input id="q1" placeholder="Sheep Creek Junction">
+        <label>Kind</label><select id="q2"><option value="junction">junction</option>
+        <option value="trailhead">trailhead</option></select>
+        <div id="meta">${through.length} track(s) pass here:<br>${
+          through.slice(0,6).map(t=>`· ${esc(t.trip)} <span style="color:#999">${t.date} · ${t.dist} m</span>`).join('<br>')
+        }${s.ele_ft!=null?`<br>elevation ${s.ele_ft} ft`:''}</div>`,
+    async () => {
+      const name = $('#q1').value.trim();
+      if (!name) { status('a junction needs a name — it is what the builder shows','err'); return false; }
+      snapshot();
+      G.nodes.push({id: await mint('nodes'), name, kind: $('#q2').value,
+                    lat:+s.lat.toFixed(6), lon:+s.lon.toFixed(6), ele_ft:s.ele_ft});
+      redraw(); await save(); status(`placed ${name}`);
+    }, map.latLngToContainerPoint(e.latlng));
+}
+
+async function pickNode(n) {
+  if (mode !== 'seg') { map.panTo([n.lat,n.lon]); return; }
+  if (!pending) { pending = {a:n.id}; redraw(); return status(`from ${n.name} — now click the far end`,'act'); }
+  if (pending.a === n.id) { pending = null; redraw(); return status('cancelled'); }
+  await makeSegment(pending.a, n.id);
+}
+
+async function makeSegment(aId, bId) {
+  const a = G.nodes.find(n=>n.id===aId), b = G.nodes.find(n=>n.id===bId);
+  status('tracing…','act');
+  const [ta, tb] = await Promise.all([
+    fetch(`/api/through?lat=${a.lat}&lon=${a.lon}`).then(r=>r.json()),
+    fetch(`/api/through?lat=${b.lat}&lon=${b.lon}`).then(r=>r.json()),
+  ]);
+  const bByKey = Object.fromEntries(tb.map(t=>[t.key,t]));
+  const shared = ta.filter(t=>bByKey[t.key])
+                   .map(t=>({key:t.key, trip:t.trip, date:t.date, i0:t.index, i1:bByKey[t.key].index,
+                             score:t.dist + bByKey[t.key].dist}))
+                   .sort((x,y)=>x.score-y.score);
+  if (!shared.length) {
+    pending = null; redraw();
+    return status('no single recorded track runs between those two — place an intermediate junction','err');
+  }
+  let choice = 0;
+  const draw = async () => {
+    const c = shared[choice];
+    const tr = await fetch(`/api/trace?key=${encodeURIComponent(c.key)}&i0=${c.i0}&i1=${c.i1}`).then(r=>r.json());
+    if (!tr.coordinates) { status('trace failed','err'); return null; }
+    return tr;
+  };
+  let tr = await draw();
+  if (!tr) { pending=null; redraw(); return; }
+  const trailOpts = G.trails.map(t=>`<option value="${t.id}">${esc(t.name)}</option>`).join('');
+  form(`<label>Segment name</label>
+        <input id="q1" value="${esc(a.name)} to ${esc(b.name)}">
+        <label>Trail${G.trails.length>1?'s (ctrl-click for concurrency)':''}</label>
+        <select id="q2" multiple size="${Math.min(5,Math.max(2,G.trails.length))}">${trailOpts}</select>
+        <label>Traced from</label>
+        <select id="q3">${shared.map((c,i)=>
+          `<option value="${i}">${esc(c.trip)} · ${c.date}</option>`).join('')}</select>
+        <div id="meta">${tr.miles} mi · +${tr.gain_ft} / −${tr.loss_ft} ft</div>`,
+    async () => {
+      const name = $('#q1').value.trim();
+      const trails = [...$('#q2').selectedOptions].map(o=>o.value);
+      if (!name) { status('name it — this is the label the builder shows','err'); return false; }
+      if (!trails.length) { status('assign at least one trail','err'); return false; }
+      const c = shared[+$('#q3').value];
+      const t2 = await fetch(`/api/trace?key=${encodeURIComponent(c.key)}&i0=${c.i0}&i1=${c.i1}`).then(r=>r.json());
+      snapshot();
+      const id = await mint('segments');
+      G.segments.push({id, name, from:aId, to:bId, trails, miles:t2.miles,
+        gain_ft:t2.gain_ft, loss_ft:t2.loss_ft, geometry:`geometry/${id}.json`,
+        sources:[t2.source], _geo:t2.coordinates});
+      pending = null; redraw(); await save(); status(`${name} — ${t2.miles} mi`);
+    }, map.latLngToContainerPoint([b.lat,b.lon]));
+  $('#q3').onchange = async () => { choice = +$('#q3').value; const t = await draw();
+    if (t) { tr = t; $('#meta').textContent = `${t.miles} mi · +${t.gain_ft} / −${t.loss_ft} ft`; } };
+}
+
+// ------------------------------------------------------------------ trails --
+$('#addTrail').onclick = () => form(
+  `<label>Trail name</label><input id="q1" placeholder="Mazatzal Divide Trail">
+   <label>Number</label><input id="q2" placeholder="FS 23 — blank if none">
+   <label>Kind</label><select id="q3"><option value="trail">trail</option><option value="road">road</option></select>`,
+  async () => {
+    const name = $('#q1').value.trim();
+    if (!name) return false;
+    snapshot();
+    G.trails.push({id: await mint('trails'), name, code: $('#q2').value.trim() || null,
+                   kind: $('#q3').value});
+    redraw(); await save(); status(`added ${name}`);
+  });
+
+// ------------------------------------------------------------------ modes --
+const setMode = m => {
+  mode = m; pending = null;
+  for (const [k,el] of [['pan','#mPan'],['node','#mNode'],['seg','#mSeg']])
+    $(el).classList.toggle('on', k===m);
+  map.getContainer().style.cursor = m==='pan' ? '' : 'crosshair';
+  status({pan:'Pan mode.', node:'Click near a track to place a junction.',
+          seg:'Click two junctions to make a segment.'}[m]);
+  redraw();
+};
+$('#mPan').onclick = ()=>setMode('pan');
+$('#mNode').onclick = ()=>setMode('node');
+$('#mSeg').onclick = ()=>setMode('seg');
+$('#showCorpus').onchange = e => e.target.checked ? corpusLayer.addTo(map) : corpusLayer.remove();
+
+document.addEventListener('keydown', e => {
+  if (/^(INPUT|SELECT|TEXTAREA)$/.test(e.target.tagName)) return;
+  if (e.key === 'n' || e.key === 'N') setMode('node');
+  else if (e.key === 's' || e.key === 'S') setMode('seg');
+  else if (e.key === 'Escape') { $('#form').style.display='none'; setMode('pan'); }
+  else if ((e.metaKey||e.ctrlKey) && e.key === 'z') { e.preventDefault(); undo(); }
+});
+
+boot().catch(err => status('failed to load: ' + err.message, 'err'));
+</script>
+</body>
+</html>

--- a/tools/curate/server.py
+++ b/tools/curate/server.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Local junction curation tool (#14).
+
+    ./tools/curate/server.py            # then open http://localhost:8723
+
+Local authoring only. This does not ship with the site and has no bearing on the
+deployed Worker, which still serves nothing but public/.
+
+Reads the recorded corpus from archive/gpx and writes curated nodes and segments to
+curation/graph.json in the schema from docs/trail-graph-schema.md.
+
+Why this can run before #10/#11/#13 land: node coordinates are authored truth and
+segment geometry is derived, so junctions placed against raw tracks stay correct when
+cleaning and traversal-merging later change the lines underneath. Only the derived
+geometry is recomputed.
+
+The browser holds a display-simplified copy of the corpus; full resolution stays here,
+so snapping and tracing are done server-side against the real points.
+"""
+import http.server, json, math, os, socketserver, sys, urllib.parse
+from collections import defaultdict
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from inventory import load, hav, M2MI, M2FT
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+HERE = os.path.dirname(os.path.abspath(__file__))
+GPX = os.path.join(ROOT, 'archive', 'gpx')
+OUT = os.path.join(ROOT, 'curation', 'graph.json')
+PORT = 8723
+
+# ---------------------------------------------------------------- corpus ----
+
+TRACKS = []   # {key, trip, date, file, pts:[(lat,lon,ele)], cum:[m]}
+
+
+def build_corpus():
+    trips, _ = load(GPX)
+    for t in trips:
+        for si, seg in enumerate(t['segs']):
+            pts = [(p[0], p[1], p[2]) for p in seg]
+            cum = [0.0]
+            for i in range(len(pts) - 1):
+                cum.append(cum[-1] + hav(pts[i][:2], pts[i+1][:2]))
+            TRACKS.append(dict(key=f"{t['file']}#{si}", trip=t['name'], date=t['date'],
+                               file=t['file'], pts=pts, cum=cum))
+    total = sum(t['cum'][-1] for t in TRACKS) * M2MI
+    print(f'corpus: {len(TRACKS)} tracks, {sum(len(t["pts"]) for t in TRACKS):,} points, {total:.1f} mi')
+
+
+def rdp(pts, eps):
+    """Douglas-Peucker on (lat,lon,...) tuples, eps in degrees-ish. Display only."""
+    if len(pts) < 3:
+        return pts
+    keep = [False] * len(pts)
+    keep[0] = keep[-1] = True
+    stack = [(0, len(pts) - 1)]
+    while stack:
+        a, b = stack.pop()
+        if b <= a + 1:
+            continue
+        ax, ay = pts[a][1], pts[a][0]
+        bx, by = pts[b][1], pts[b][0]
+        dx, dy = bx - ax, by - ay
+        n = math.hypot(dx, dy)
+        best, bi = -1.0, -1
+        for i in range(a + 1, b):
+            px, py = pts[i][1], pts[i][0]
+            d = abs(dy * px - dx * py + bx * ay - by * ax) / n if n else math.hypot(px - ax, py - ay)
+            if d > best:
+                best, bi = d, i
+        if best > eps:
+            keep[bi] = True
+            stack += [(a, bi), (bi, b)]
+    return [p for p, k in zip(pts, keep) if k]
+
+
+def corpus_geojson():
+    feats = []
+    for t in TRACKS:
+        simp = rdp(t['pts'], 0.00008)   # ~9 m
+        feats.append({
+            'type': 'Feature',
+            'properties': {'key': t['key'], 'trip': t['trip'], 'date': t['date'],
+                           'file': t['file'], 'miles': round(t['cum'][-1] * M2MI, 2)},
+            'geometry': {'type': 'LineString',
+                         'coordinates': [[round(p[1], 6), round(p[0], 6)] for p in simp]},
+        })
+    return {'type': 'FeatureCollection', 'features': feats}
+
+
+# ----------------------------------------------------------- snap / trace ----
+
+def snap(lat, lon, limit=60.0):
+    """Nearest point on any track. Junctions belong on the tread, not beside it."""
+    best = None
+    for t in TRACKS:
+        for i, p in enumerate(t['pts']):
+            d = hav((lat, lon), p[:2])
+            if best is None or d < best['dist']:
+                best = dict(dist=d, key=t['key'], index=i, lat=p[0], lon=p[1],
+                            ele=p[2], trip=t['trip'], date=t['date'])
+    if best and best['dist'] <= limit:
+        best['ele_ft'] = round(best['ele'] * M2FT) if best['ele'] is not None else None
+        return best
+    return None
+
+
+def tracks_through(lat, lon, tol=40.0):
+    """Which recorded tracks pass within tol of this point, and where."""
+    out = []
+    for t in TRACKS:
+        best_i, best_d = None, 1e9
+        for i, p in enumerate(t['pts']):
+            d = hav((lat, lon), p[:2])
+            if d < best_d:
+                best_d, best_i = d, i
+        if best_d <= tol:
+            out.append(dict(key=t['key'], index=best_i, dist=round(best_d, 1),
+                            trip=t['trip'], date=t['date']))
+    return sorted(out, key=lambda x: x['dist'])
+
+
+def profile_gain_loss(eles, threshold_m=5.0):
+    """Gain and loss with the direction-symmetric algorithm the schema prescribes:
+    simplify the elevation profile first, then sum. Reversing the input swaps the
+    two results exactly, which is what lets a segment store one pair of numbers."""
+    e = [x for x in eles if x is not None]
+    if len(e) < 2:
+        return 0.0, 0.0
+    ext = [e[0]]
+    for v in e[1:]:
+        if len(ext) < 2:
+            if v != ext[-1]:
+                ext.append(v)
+            continue
+        up_prev = ext[-1] > ext[-2]
+        up_now = v > ext[-1]
+        if v == ext[-1]:
+            continue
+        if up_now == up_prev:
+            ext[-1] = v            # extend the run
+        else:
+            ext.append(v)          # direction changed
+    while len(ext) > 2:
+        runs = [(abs(ext[i+1] - ext[i]), i) for i in range(len(ext) - 1)]
+        interior = [(m, i) for m, i in runs if 0 < i < len(ext) - 2]
+        if not interior:
+            break
+        m, i = min(interior)
+        if m >= threshold_m:
+            break
+        del ext[i:i+2]             # drop the reversal, neighbours merge
+        merged = [ext[0]]
+        for v in ext[1:]:
+            if len(merged) >= 2 and (v > merged[-1]) == (merged[-1] > merged[-2]):
+                merged[-1] = v
+            elif v != merged[-1]:
+                merged.append(v)
+        ext = merged
+    gain = sum(max(0.0, ext[i+1] - ext[i]) for i in range(len(ext) - 1))
+    loss = sum(max(0.0, ext[i] - ext[i+1]) for i in range(len(ext) - 1))
+    return gain, loss
+
+
+def trace(key, i0, i1):
+    """Sub-path of one recorded track between two snapped indices."""
+    t = next((x for x in TRACKS if x['key'] == key), None)
+    if t is None:
+        return None
+    a, b = (i0, i1) if i0 <= i1 else (i1, i0)
+    pts = t['pts'][a:b+1]
+    if len(pts) < 2:
+        return None
+    metres = t['cum'][b] - t['cum'][a]
+    gain, loss = profile_gain_loss([p[2] for p in pts])
+    if i0 > i1:
+        pts = pts[::-1]
+        gain, loss = loss, gain
+    return dict(coordinates=[[round(p[1], 6), round(p[0], 6)] for p in rdp(pts, 0.00003)],
+                miles=round(metres * M2MI, 2),
+                gain_ft=round(gain * M2FT), loss_ft=round(loss * M2FT),
+                source=dict(file=t['file'], date=t['date']))
+
+
+# ------------------------------------------------------------------ state ----
+
+EMPTY = {'version': 1, 'trails': [], 'nodes': [], 'segments': [], 'features': [], 'retired': []}
+
+
+GEO = os.path.join(os.path.dirname(OUT), 'geometry')
+
+
+def read_state():
+    """Load the curated graph, re-attaching each segment's geometry for display.
+
+    Geometry lives in its own file per segment, exactly as the schema requires, so
+    graph.json stays small and schema-valid. The browser needs the points to draw, so
+    they are attached under a leading-underscore key that write_state strips again."""
+    if not os.path.exists(OUT):
+        return json.loads(json.dumps(EMPTY))
+    state = json.load(open(OUT))
+    for seg in state.get('segments', []):
+        f = os.path.join(GEO, f"{seg['id']}.json")
+        if os.path.exists(f):
+            seg['_geo'] = json.load(open(f))['coordinates']
+    return state
+
+
+def write_state(state):
+    """Persist atomically. An interrupted save must never truncate a curation sitting."""
+    os.makedirs(GEO, exist_ok=True)
+    state = json.loads(json.dumps(state))
+    for seg in state.get('segments', []):
+        geo = seg.pop('_geo', None)
+        if geo is not None:
+            gp = os.path.join(GEO, f"{seg['id']}.json")
+            tmp = gp + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump({'type': 'LineString', 'coordinates': geo}, f)
+            os.replace(tmp, gp)
+        seg['geometry'] = f"geometry/{seg['id']}.json"
+    tmp = OUT + '.tmp'
+    with open(tmp, 'w') as f:
+        json.dump(state, f, indent=2)
+        f.write('\n')
+    os.replace(tmp, OUT)
+
+
+ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+
+def mint(state, kind):
+    """Next free code. Ids are allocated, never derived, and retired ids are never
+    reissued -- see decision 1 in docs/trail-graph-schema.md."""
+    used = {x['id'] for x in state.get(kind, [])}
+    if kind == 'segments':
+        used |= {r['id'] for r in state.get('retired', [])}
+    for a in ALPHABET:
+        for b in ALPHABET:
+            c = a + b
+            if c not in used:
+                return c
+    raise RuntimeError('id space exhausted')
+
+
+# ----------------------------------------------------------------- server ----
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _send(self, obj, code=200):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        u = urllib.parse.urlparse(self.path)
+        q = urllib.parse.parse_qs(u.query)
+        if u.path in ('/', '/index.html'):
+            body = open(os.path.join(HERE, 'index.html'), 'rb').read()
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.send_header('Content-Length', str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif u.path == '/api/corpus':
+            self._send(corpus_geojson())
+        elif u.path == '/api/graph':
+            self._send(read_state())
+        elif u.path == '/api/snap':
+            self._send(snap(float(q['lat'][0]), float(q['lon'][0])) or {})
+        elif u.path == '/api/through':
+            self._send(tracks_through(float(q['lat'][0]), float(q['lon'][0])))
+        elif u.path == '/api/trace':
+            r = trace(q['key'][0], int(q['i0'][0]), int(q['i1'][0]))
+            self._send(r or {}, 200 if r else 404)
+        else:
+            self._send({'error': 'not found'}, 404)
+
+    def do_POST(self):
+        u = urllib.parse.urlparse(self.path)
+        n = int(self.headers.get('Content-Length', 0))
+        payload = json.loads(self.rfile.read(n) or b'{}')
+        state = read_state()
+
+        if u.path == '/api/graph':
+            write_state(payload)
+            self._send({'ok': True})
+        elif u.path == '/api/mint':
+            self._send({'id': mint(state, payload['kind'])})
+        else:
+            self._send({'error': 'not found'}, 404)
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+if __name__ == '__main__':
+    build_corpus()
+    s = read_state()
+    print(f'curation: {len(s["nodes"])} nodes, {len(s["segments"])} segments  ->  '
+          f'{os.path.relpath(OUT, ROOT)}')
+    print(f'\n  http://localhost:{PORT}\n')
+    try:
+        Server(('127.0.0.1', PORT), Handler).serve_forever()
+    except KeyboardInterrupt:
+        print('stopped')


### PR DESCRIPTION
Closes #14.

```
./tools/curate/server.py      # then open http://localhost:8723
```

Python stdlib plus Leaflet from a CDN — no install step, no build. Local authoring only; the deployed Worker still serves nothing but `public/`.

## It runs before the pipeline, on purpose

#14 asks for "cleaned canonical lines," which #10, #11 and #13 haven't produced. That turns out not to block anything, because of how the merged schema splits authored truth from derived data: **node coordinates are authored, segment geometry is derived.** A junction placed against a raw recorded track stays in exactly the right place when cleaning and traversal-merging later change the lines underneath.

So the durable output — node positions, which nodes connect, what the legs are called — survives the pipeline landing afterwards. The distances and gain figures written today *are* provisional and get recomputed from the canonical lines once #13 exists. That's stated in the README so it doesn't come as a surprise later.

## What makes many dozens of junctions tolerable

That's the ticket's actual bar, so it drove the design:

- **Clicks snap to recorded tread** — within 60 m onto the nearest real point, refused beyond it rather than inventing a junction out in open country
- **The placement form shows which trips pass through, and on what dates** — usually how you recognise which junction you're looking at
- **Segments trace along a real recorded track** between two junctions rather than drawing a straight line, so a leg's geometry is ground actually walked. Where several trips cover the stretch you choose which to trace, and that choice lands in the segment's `sources`
- Keyboard driven (<kbd>N</kbd> node, <kbd>S</kbd> segment, <kbd>Esc</kbd>, <kbd>⌘Z</kbd>), save after every change, atomic writes so an interrupted save can't truncate a sitting

## Schema conformance

Geometry is written per segment under `curation/geometry/` and stripped from `graph.json`, so curated output is schema-valid as it stands:

```
$ ./tools/validate_graph.py curation/graph.json
1 trails  2 nodes  1 segments  0 features  0 retired  12.0 mi
valid
```

Gain uses the direction-symmetric algorithm the schema prescribes. Verified against 300 synthetic profiles and 137 real slices from the corpus — reversing a segment swaps gain and loss **exactly**, which is what justifies storing one pair of numbers instead of two.

## Verification, and its limit

Exercised end to end through the API: corpus load (29 tracks, 13k display points, 0.13 s), snapping including correct refusal 100 km from any track, tracing (12.03 mi, +3629/−2828 ft off the Club Cabin track), reversal symmetry, save, reload with geometry reattached, and schema validation of the result. Snap is ~20 ms.

**The UI itself has not been opened in a browser** — the Chrome extension isn't connected here, so the client JS is syntax-checked only. Worth a look before you rely on it for a long sitting.

## Known limits (all in the README)

- A segment needs one recorded track running through **both** its junctions. Where no single trip covers the stretch the tool says so and asks for an intermediate junction; stitching across two trips isn't built, since whether it's worth it depends on how often it actually comes up.
- Features (springs, cabins, camps) can't be placed yet — junctions and segments first, since those are what the network is made of.
- No editing or deletion beyond undo within a sitting.

`curation/` is gitignored while the pass is in progress; committing the finished graph is #15's business, along with the real judgment call of what counts as a junction worth modelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141MiRkKvCec62meV97gvck