### PR TITLE
Stop segment ids colliding by case on the filesystem

### DIFF
--- a/docs/trail-graph-schema.md
+++ b/docs/trail-graph-schema.md
@@ -56,12 +56,22 @@ pipeline order is worse: inserting one junction renumbers everything after it.
 So ids are data, not a function of data. The registry lives in `graph.json` itself; the
 tool reads the highest allocated code and takes the next.
 
-**Format: base62 (`0-9A-Za-z`), case-sensitive, 2 characters minimum.** Two characters
-hold 3,844 values. The corpus suggests somewhere between "many dozens" and a pessimistic
-upper bound of ~850 segments, so two characters cover the network with a wide margin, and
-a 15-leg shared route costs about 45 characters of ids. Each entity type has its own id
-space — a node `4F` and a segment `4F` are unrelated, and the field name always says which
-is meant.
+**Format: base62 (`0-9A-Za-z`), 2 characters minimum — but two ids may never differ only
+by case.** Two characters hold 3,844 values on paper. In practice a segment's geometry is
+one file per id, and both macOS (APFS) and Windows are case-insensitive by default, so
+minting `0a` alongside `0A` makes the two resolve to the same path and the second write
+destroys the first silently — nothing downstream can detect it, and `validate_graph.py`
+never opens the geometry files. So `mint()` tests uniqueness case-folded, which leaves
+**1,296** usable two-character codes. The corpus suggests somewhere between "many dozens"
+and a pessimistic upper bound of ~850 segments, so two characters still cover the network,
+though with less margin than the raw base62 count implies; three characters remain
+available if that bound is ever approached. A 15-leg shared route costs about 45 characters
+of ids. Each entity type has its own id space — a node `4F` and a segment `4F` are
+unrelated, and the field name always says which is meant.
+
+The stored format is unchanged and stays case-sensitive: `^[0-9A-Za-z]{2,4}$` still
+validates, and ids already allocated in both cases remain legal. Only *allocation* is
+constrained.
 
 **Splitting a segment retires its id.** When curation discovers a real junction partway
 along an existing leg, that leg does not keep its id for the longer half — that would

--- a/tools/curate/server.py
+++ b/tools/curate/server.py
@@ -211,6 +211,14 @@ def write_state(state):
     """Persist atomically. An interrupted save must never truncate a curation sitting."""
     os.makedirs(GEO, exist_ok=True)
     state = json.loads(json.dumps(state))
+    seen = {}
+    for seg in state.get('segments', []):
+        # Refuse to write rather than let one segment's line overwrite another's on a
+        # case-insensitive filesystem. mint() prevents this; this catches hand-edits.
+        if seg['id'].lower() in seen:
+            raise ValueError(f"segment ids {seen[seg['id'].lower()]!r} and {seg['id']!r} "
+                             f"differ only by case and share one geometry file")
+        seen[seg['id'].lower()] = seg['id']
     for seg in state.get('segments', []):
         geo = seg.pop('_geo', None)
         if geo is not None:
@@ -232,14 +240,22 @@ ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 
 def mint(state, kind):
     """Next free code. Ids are allocated, never derived, and retired ids are never
-    reissued -- see decision 1 in docs/trail-graph-schema.md."""
-    used = {x['id'] for x in state.get(kind, [])}
+    reissued -- see decision 1 in docs/trail-graph-schema.md.
+
+    Ids must also differ by more than case. The schema's alphabet is case-sensitive
+    base62, but a segment's geometry is one file per id, and macOS (APFS) and Windows
+    are case-insensitive: minting `0a` alongside `0A` makes both resolve to the same
+    path, and the second write silently destroys the first. So uniqueness is tested
+    case-folded, which costs the lowercase half of the space (1,296 two-character ids
+    remain, still clear of the ~850 upper bound in the schema doc) and buys back a
+    class of data loss that nothing downstream can detect."""
+    used = {x['id'].lower() for x in state.get(kind, [])}
     if kind == 'segments':
-        used |= {r['id'] for r in state.get('retired', [])}
+        used |= {r['id'].lower() for r in state.get('retired', [])}
     for a in ALPHABET:
         for b in ALPHABET:
             c = a + b
-            if c not in used:
+            if c.lower() not in used:
                 return c
     raise RuntimeError('id space exhausted')
 


### PR DESCRIPTION
Closes a silent data-loss bug in the curation tool, found while auditing the segments added in the current pass.

## The bug

Segment geometry is one file per id (`curation/geometry/<id>.json`), and the id alphabet is case-sensitive base62. Both APFS and Windows are case-insensitive by default, so `0a` and `0A` are the same path — minting a lowercase id alongside an existing uppercase one had the second write destroy the first.

It had already happened three times in the live pass. `0A`, `0B` and `0C` were drawing `0a`, `0b` and `0c`'s lines, with their geometry sitting **4–8 km** from their own endpoints:

| segment | was drawing |
|---|---|
| `0A` Divide, Sandy Saddle → Horse Camp Seep | Deadman → Club Ranch |
| `0B` Divide, Horse Camp Seep → Rock Creek | Club Ranch → Chilson (5.89 mi) |
| `0C` Divide, Y-Bar → Brody Seep (S) | Horse Camp Seep Spur (0.09 mi) |

Nothing caught it. `validate_graph.py` reported the graph valid because it never opens the geometry files — the map simply drew the wrong line.

## The fix

- `mint()` tests uniqueness **case-folded**, so a colliding pair is never allocated.
- `write_state()` **refuses to write** a state containing one, covering hand-edited graphs that `mint()` never saw. The check completes before any file is touched, so a refusal leaves the sitting untouched rather than half-written. (This fired during the recovery and prevented a bad write, so it is load-bearing rather than theoretical.)

## Cost

The lowercase half of the id space: **1,296** two-character codes rather than 3,844, still clear of the ~850 pessimistic upper bound in the schema doc, with three characters available beyond that. The stored format is unchanged and stays case-sensitive — `^[0-9A-Za-z]{2,4}$` still validates and ids already allocated in both cases remain legal. Only *allocation* is constrained. `docs/trail-graph-schema.md` is updated to say so, since it still claimed a flat 3,844.

## Recovery

Not in this PR — `curation/` is gitignored while the pass is in progress. Locally, the three lines were re-traced from their sources and each reproduced its stored mileage and gain/loss exactly, confirming the originals came back rather than something merely plausible. The lowercase ids moved to `10`/`11`/`12`; no tombstones, as they never left the sitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2KFUKLedxx4kAjJaDa3Zv