### PR TITLE
Harden the curation tool against silently wrong geometry

### DIFF
--- a/docs/trail-graph-schema.md
+++ b/docs/trail-graph-schema.md
@@ -60,8 +60,10 @@ tool reads the highest allocated code and takes the next.
 by case.** Two characters hold 3,844 values on paper. In practice a segment's geometry is
 one file per id, and both macOS (APFS) and Windows are case-insensitive by default, so
 minting `0a` alongside `0A` makes the two resolve to the same path and the second write
-destroys the first silently — nothing downstream can detect it, and `validate_graph.py`
-never opens the geometry files. So `mint()` tests uniqueness case-folded, which leaves
+destroys the first silently — the damage itself is undetectable downstream, since
+`validate_graph.py` never opens the geometry files. So `mint()` tests uniqueness
+case-folded, and the validator rejects a colliding *pair of ids* in any graph it is handed,
+whichever filesystem authored it. That leaves
 **1,296** usable two-character codes. The corpus suggests somewhere between "many dozens"
 and a pessimistic upper bound of ~850 segments, so two characters still cover the network,
 though with less margin than the raw base62 count implies; three characters remain
@@ -149,6 +151,55 @@ a note meaningful, so it always travels with the text (#17). The file is authore
 and read by the builder popup, the export descriptions, and any future page, so all three
 surfaces show the same record and cannot drift.
 
+### 5. A road is a segment only when it was walked
+
+**Decision: a road enters the graph on the same terms as a trail — a recorded track, with
+`sources`. A road that merely exists on the map does not, however useful it would be.**
+
+Decision 2 makes roads first-class, and they earn it: FR 201 links three crest trailheads
+in 1.47 mi and collapses a 15.7 mi detour, which is the difference between a loop and a
+car shuttle. The temptation is then to draw in the road you *know* is there — the graded
+roads reaching Fig Trailhead from the Davenport side, say.
+
+Two reasons not to, either sufficient. **Provenance:** every segment carries the file and
+date it came from, and an unwalked road has none, so its geometry would have to be
+invented — which the curation tool refuses to do by design. **Consequence:** anything in
+the graph is clickable, so the builder would hand someone a route down ground nobody has
+checked, rendered identically to ground walked twice. "It is on the Forest Service map" is
+exactly the secondhand claim this project exists not to make.
+
+The corollary is that the connectors worth adding are *findable*: a walked connector is a
+recorded arc between two existing nodes with no third node between them and no segment yet.
+That search is exhaustive over the corpus. What it cannot do is judge — the same search
+surfaces a road that makes a loop work, a road best left off the map, and a thick bushwhack
+down a creek, and nothing in a GPX tells them apart. Generate the candidates mechanically,
+decide them by hand.
+
+### 6. An unreachable component is declared, not silenced
+
+**Decision: `islands` records a component deliberately left unconnected, with the reason.
+An undeclared split stays an error.**
+
+The connectivity check earns its keep — it has caught a missed 0.08 mi connector between
+two trailhead nodes 118 m apart, which nothing else would have. So when a real island turns
+up, the fix is not to downgrade the check to a warning.
+
+And real islands exist. Fig Trailhead is reached by kayak across the Verde; the recorded
+trip shares no ground with any other, and its far bank is 2.08 mi from the nearest node, so
+no walked route reaches it and none ever will without a new trip. That is geography, not a
+curation gap.
+
+The crossing itself is **not** a segment. It is not walkable, so it cannot sit in a network
+whose legs are summed into a route with no way to say "bring a boat" — and it would not
+help anyway, since modelling it only extends the island to the west bank. It belongs in
+`observations.json`, attached to the trailhead node: a dated, first-person note about an
+entry point, which is what it actually is.
+
+So the island is declared in the graph, listing the component's nodes **exactly**. If it
+later grows or shrinks the declaration stops matching and the error returns, which is the
+point — the exception is a reviewed act with a date on it, like retiring an id, not a
+permanent hole in the check.
+
 ## Two constraints the schema has to satisfy
 
 ### A route may end partway along its last leg
@@ -204,6 +255,10 @@ of the project and must survive into the graph).
 
 **feature** — `id`, `name`, `kind` (`water` | `camp` | `cabin` | `viewpoint` | `ruin` |
 `ford`), `lat`, `lon`, and the derived `on` / `at` placing it along a segment.
+
+**island** — `nodes` (every node id in the isolated component, exactly), `on`, `reason`.
+Declares a component no walked route reaches; an undeclared split is an error. See
+decision 6.
 
 Coordinates are the authored truth for nodes and features; `on` and `at` are **derived**
 at build time by projecting onto the segment. Storing the projection as truth would make

--- a/schema/graph.schema.json
+++ b/schema/graph.schema.json
@@ -17,11 +17,16 @@
       "description": "Tombstones for ids withdrawn from use, so already-shared route URLs can be repaired rather than silently changing meaning. Never reissue a retired id.",
       "type": "array",
       "items": { "$ref": "#/$defs/retired" }
+    },
+    "islands": {
+      "description": "Components deliberately left unconnected, each with the reason no walked route reaches them. An undeclared split is an error.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/island" }
     }
   },
   "$defs": {
     "id": {
-      "description": "Assigned once by the curation tool from the next free code; never derived from geometry or ordering. Each entity type has its own id space.",
+      "description": "Assigned once by the curation tool from the next free code; never derived from geometry or ordering. Each entity type has its own id space. Ids in a space must be unique case-insensitively: segment geometry lives at geometry/<id>.json, and case-insensitive filesystems collapse 0A and 0a onto one file, destroying the older segment's line. See decision 1.",
       "type": "string",
       "pattern": "^[0-9A-Za-z]{2,4}$"
     },
@@ -136,6 +141,26 @@
         },
         "on": { "type": "string", "format": "date" },
         "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "island": {
+      "description": "A component of the network deliberately not reachable on foot from the rest of it. Declaring one is a reviewed act, like retiring an id: the validator treats an undeclared split as an error, because it is almost always a missed junction rather than real geography.",
+      "type": "object",
+      "required": ["nodes", "on", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "description": "Every node in the isolated component, exactly. If the component later grows or shrinks the declaration stops matching and must be re-reviewed.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "on": { "type": "string", "format": "date" },
+        "reason": {
+          "description": "Why no walked route reaches it — surfaced by the builder when someone lands on this component.",
+          "type": "string",
+          "minLength": 1
+        }
       }
     }
   }

--- a/tools/curate/README.md
+++ b/tools/curate/README.md
@@ -34,13 +34,25 @@ from the canonical lines once #13 exists.
 
 **Clicks snap to the recorded tread.** A click within 60 m moves onto the nearest recorded
 point; further out it is refused rather than inventing a junction in open country. The form
-then shows which tracks pass through and on what dates, which is usually how you recognise
-what junction you are looking at.
+then shows every pass through the point and on what dates, which is usually how you recognise
+what junction you are looking at. A trip listed twice doubled back through here — worth
+noticing, for the reason below.
 
 **Segments trace along a real recorded track.** Picking two junctions finds the tracks that
 pass through both and follows one between them, so a leg's geometry is ground you actually
-walked rather than a straight line. Where several trips cover the stretch, the form lets you
-choose which one to trace, and the chosen track is recorded in the segment's `sources`.
+walked rather than a straight line. The chosen track is recorded in the segment's `sources`.
+
+**A track can run between two junctions more than one way**, and this is the tool's sharpest
+edge. On a loop or an out-and-back a trip comes through the same junction twice, so the two
+endpoints can land on different visits and the sub-path between them runs most of the way
+round the loop — a two-tenths-of-a-mile hop recorded as thirty miles. So the form enumerates
+every arc, labels each with its length, and defaults to the shortest, which is the leg where
+the alternative is the rest of the loop. Among arcs that are effectively the same leg
+recorded on different trips, the tightest snap wins instead.
+
+**The candidate leg is drawn on the map in orange before you save it**, and pulled into view
+if it does not already fit. A wrong way round is obvious as a line and invisible as a number,
+so look at the line.
 
 Distance and elevation come from the traced points. Gain uses the direction-symmetric
 algorithm the schema prescribes — simplify the profile, then sum — so reversing a segment

--- a/tools/curate/index.html
+++ b/tools/curate/index.html
@@ -91,6 +91,7 @@ L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
 
 const corpusLayer = L.layerGroup().addTo(map);
 const graphLayer  = L.layerGroup().addTo(map);
+const previewLayer = L.layerGroup().addTo(map);   // the arc a segment would take, before saving
 
 const status = (m, cls='') => { const s=$('#status'); s.textContent=m; s.className=cls; };
 
@@ -189,7 +190,7 @@ function form(html, onOk, at) {
   f.style.left = Math.min(pt.x + 14, window.innerWidth - 660) + 'px';
   f.style.top  = Math.min(pt.y, window.innerHeight - 300) + 'px';
   const first = f.querySelector('input,select'); if (first) { first.focus(); first.select?.(); }
-  const close = () => { f.style.display='none'; pending=null; redraw(); };
+  const close = () => { f.style.display='none'; previewLayer.clearLayers(); pending=null; redraw(); };
   $('#fNo').onclick = close;
   $('#fOk').onclick = async () => { const r = await onOk(); if (r !== false) close(); };
   f.onkeydown = e => {
@@ -213,7 +214,9 @@ async function placeNode(e) {
   form(`<label>Junction name</label><input id="q1" placeholder="Sheep Creek Junction">
         <label>Kind</label><select id="q2"><option value="junction">junction</option>
         <option value="trailhead">trailhead</option></select>
-        <div id="meta">${through.length} track(s) pass here:<br>${
+        <div id="meta">${through.length} recorded pass(es) here${
+          new Set(through.map(t=>t.key)).size < through.length
+            ? ' — a trip listed twice doubled back through this point' : ''}:<br>${
           through.slice(0,6).map(t=>`· ${esc(t.trip)} <span style="color:#999">${t.date} · ${t.dist} m</span>`).join('<br>')
         }${s.ele_ft!=null?`<br>elevation ${s.ele_ft} ft`:''}</div>`,
     async () => {
@@ -236,25 +239,40 @@ async function pickNode(n) {
 async function makeSegment(aId, bId) {
   const a = G.nodes.find(n=>n.id===aId), b = G.nodes.find(n=>n.id===bId);
   status('tracing…','act');
-  const [ta, tb] = await Promise.all([
-    fetch(`/api/through?lat=${a.lat}&lon=${a.lon}`).then(r=>r.json()),
-    fetch(`/api/through?lat=${b.lat}&lon=${b.lon}`).then(r=>r.json()),
-  ]);
-  const bByKey = Object.fromEntries(tb.map(t=>[t.key,t]));
-  const shared = ta.filter(t=>bByKey[t.key])
-                   .map(t=>({key:t.key, trip:t.trip, date:t.date, i0:t.index, i1:bByKey[t.key].index,
-                             score:t.dist + bByKey[t.key].dist}))
-                   .sort((x,y)=>x.score-y.score);
+  // One call, because pairing the two ends is the server's job: either end can fall on
+  // several visits of the same track, and every pairing is a different way round.
+  // Shortest arc first — see arcs() in server.py.
+  const shared = await fetch(
+    `/api/arcs?alat=${a.lat}&alon=${a.lon}&blat=${b.lat}&blon=${b.lon}`).then(r=>r.json());
   if (!shared.length) {
     pending = null; redraw();
     return status('no single recorded track runs between those two — place an intermediate junction','err');
   }
   let choice = 0;
+  // Show the line before it is committed. A leg that runs the wrong way round a loop is
+  // obvious on the map and invisible in a mileage figure, so pull it into view when it
+  // does not already fit — that is the whole tell.
   const draw = async () => {
     const c = shared[choice];
     const tr = await fetch(`/api/trace?key=${encodeURIComponent(c.key)}&i0=${c.i0}&i1=${c.i1}`).then(r=>r.json());
     if (!tr.coordinates) { status('trace failed','err'); return null; }
+    previewLayer.clearLayers();
+    const line = L.polyline(tr.coordinates.map(p=>[p[1],p[0]]),
+                            {color:'#e08a00', weight:6, opacity:.9}).addTo(previewLayer);
+    if (!map.getBounds().contains(line.getBounds())) map.fitBounds(line.getBounds(), {padding:[60,60]});
     return tr;
+  };
+  const mi = n => Number(n).toFixed(2);
+  // Warn only where the same track also runs a substantially longer way between these two
+  // nodes — that is the loop, and the thing worth a second look. A track that merely walked
+  // the leg twice offers two arcs of the same length, which is not worth saying.
+  const metaHtml = tr => {
+    const c = shared[choice];
+    const longer = shared.filter(x => x.key === c.key && x.miles > c.miles * 1.5);
+    return `${mi(tr.miles)} mi · +${tr.gain_ft} / −${tr.loss_ft} ft` + (!longer.length ? '' :
+      `<br><span style="color:#b4530a">${esc(c.trip)} comes through both ends more than once —`
+      + ` it also runs between them the long way, up to ${mi(longer[longer.length-1].miles)} mi.`
+      + ` Check the orange line.</span>`);
   };
   let tr = await draw();
   if (!tr) { pending=null; redraw(); return; }
@@ -262,27 +280,41 @@ async function makeSegment(aId, bId) {
   form(`<label>Segment name</label>
         <input id="q1" value="${esc(a.name)} to ${esc(b.name)}">
         <label>Trail${G.trails.length>1?'s (ctrl-click for concurrency)':''}</label>
-        <select id="q2" multiple size="${Math.min(5,Math.max(2,G.trails.length))}">${trailOpts}</select>
+        ${G.trails.length
+          ? `<select id="q2" multiple size="${Math.min(5,Math.max(2,G.trails.length))}">${trailOpts}</select>`
+          : ''}
+        <input id="q4" style="margin-top:${G.trails.length?'4px':'0'}"
+               placeholder="${G.trails.length ? 'or name a new trail' : 'name the trail — e.g. Davenport Trail'}">
         <label>Traced from</label>
         <select id="q3">${shared.map((c,i)=>
-          `<option value="${i}">${esc(c.trip)} · ${c.date}</option>`).join('')}</select>
-        <div id="meta">${tr.miles} mi · +${tr.gain_ft} / −${tr.loss_ft} ft</div>`,
+          `<option value="${i}">${esc(c.trip)} · ${c.date} · ${mi(c.miles)} mi</option>`).join('')}</select>
+        <div id="meta">${metaHtml(tr)}</div>`,
     async () => {
       const name = $('#q1').value.trim();
-      const trails = [...$('#q2').selectedOptions].map(o=>o.value);
+      const fresh = $('#q4').value.trim();
+      const picked = G.trails.length ? [...$('#q2').selectedOptions].map(o=>o.value) : [];
       if (!name) { status('name it — this is the label the builder shows','err'); return false; }
-      if (!trails.length) { status('assign at least one trail','err'); return false; }
+      if (!picked.length && !fresh) {
+        status('assign a trail, or name a new one','err'); return false;
+      }
       const c = shared[+$('#q3').value];
       const t2 = await fetch(`/api/trace?key=${encodeURIComponent(c.key)}&i0=${c.i0}&i1=${c.i1}`).then(r=>r.json());
       snapshot();
+      const trails = [...picked];
+      if (fresh) {
+        const tid = await mint('trails');
+        G.trails.push({id:tid, name:fresh, code:null, kind:'trail'});
+        trails.push(tid);
+      }
       const id = await mint('segments');
       G.segments.push({id, name, from:aId, to:bId, trails, miles:t2.miles,
         gain_ft:t2.gain_ft, loss_ft:t2.loss_ft, geometry:`geometry/${id}.json`,
         sources:[t2.source], _geo:t2.coordinates});
-      pending = null; redraw(); await save(); status(`${name} — ${t2.miles} mi`);
+      pending = null; redraw(); await save();
+      status(`${name} — ${t2.miles} mi${fresh?` · new trail "${fresh}"`:''}`);
     }, map.latLngToContainerPoint([b.lat,b.lon]));
   $('#q3').onchange = async () => { choice = +$('#q3').value; const t = await draw();
-    if (t) { tr = t; $('#meta').textContent = `${t.miles} mi · +${t.gain_ft} / −${t.loss_ft} ft`; } };
+    if (t) { tr = t; $('#meta').innerHTML = metaHtml(t); } };
 }
 
 // ------------------------------------------------------------------ trails --

--- a/tools/curate/server.py
+++ b/tools/curate/server.py
@@ -106,19 +106,78 @@ def snap(lat, lon, limit=60.0):
     return None
 
 
+def passes_through(t, lat, lon, tol=40.0):
+    """Every distinct approach of one track to a point, not just its closest.
+
+    A loop or an out-and-back comes near the same junction more than once, and
+    each visit is a separate place the tread could be cut. Collapsing them to the
+    single nearest one is what let a segment silently trace the long way round:
+    two endpoints landed on different visits and the sub-path between them ran
+    most of the way round the loop. Consecutive points inside tol are one visit,
+    represented by the nearest of them."""
+    ds = [hav((lat, lon), p[:2]) for p in t['pts']]
+    out, i, n = [], 0, len(ds)
+    while i < n:
+        if ds[i] > tol:
+            i += 1
+            continue
+        j = i
+        while j < n and ds[j] <= tol:
+            j += 1
+        k = min(range(i, j), key=lambda x: ds[x])
+        out.append((k, ds[k]))
+        i = j
+    return out
+
+
 def tracks_through(lat, lon, tol=40.0):
-    """Which recorded tracks pass within tol of this point, and where."""
+    """Which recorded tracks pass within tol of this point, and where. One entry
+    per visit, so a track that doubles back through a junction is listed twice --
+    which is itself the tell that the junction sits on a loop or an out-and-back."""
     out = []
     for t in TRACKS:
-        best_i, best_d = None, 1e9
-        for i, p in enumerate(t['pts']):
-            d = hav((lat, lon), p[:2])
-            if d < best_d:
-                best_d, best_i = d, i
-        if best_d <= tol:
-            out.append(dict(key=t['key'], index=best_i, dist=round(best_d, 1),
+        for i, d in passes_through(t, lat, lon, tol):
+            out.append(dict(key=t['key'], index=i, dist=round(d, 1),
                             trip=t['trip'], date=t['date']))
     return sorted(out, key=lambda x: x['dist'])
+
+
+MIN_ARC_M = 10.0
+
+
+def arcs(alat, alon, blat, blon, tol=40.0, limit=12):
+    """Every sub-path of a single recorded track running between two points.
+
+    Either endpoint can fall on more than one visit, so pairing them is a cross
+    product rather than a lookup, and each pair is a genuinely different way
+    round. Shortest first: where one track offers two arcs between the same pair,
+    the short one is the leg and the long one is the rest of the loop.
+
+    Arcs within a short way of the shortest are all the same leg recorded on
+    different trips, where length says nothing -- so inside that band the
+    tightest snap wins, which is the older behaviour and still the right one.
+    The caller gets the whole list either way, because the point is to make the
+    choice visible rather than to guess well silently."""
+    out = []
+    for t in TRACKS:
+        pa = passes_through(t, alat, alon, tol)
+        if not pa:
+            continue
+        pb = passes_through(t, blat, blon, tol)
+        for ia, da in pa:
+            for ib, db in pb:
+                metres = abs(t['cum'][ib] - t['cum'][ia])
+                if metres < MIN_ARC_M:
+                    continue
+                out.append(dict(key=t['key'], trip=t['trip'], date=t['date'],
+                                i0=ia, i1=ib, miles=round(metres * M2MI, 2),
+                                off_m=round(da + db)))
+    out.sort(key=lambda x: (x['miles'], x['off_m']))
+    if out:
+        band = out[0]['miles'] + max(0.05, out[0]['miles'] * 0.1)
+        same = sorted((x for x in out if x['miles'] <= band), key=lambda x: (x['off_m'], x['miles']))
+        out = same + [x for x in out if x['miles'] > band]
+    return out[:limit]
 
 
 def profile_gain_loss(eles, threshold_m=5.0):
@@ -292,6 +351,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self._send(snap(float(q['lat'][0]), float(q['lon'][0])) or {})
         elif u.path == '/api/through':
             self._send(tracks_through(float(q['lat'][0]), float(q['lon'][0])))
+        elif u.path == '/api/arcs':
+            self._send(arcs(float(q['alat'][0]), float(q['alon'][0]),
+                            float(q['blat'][0]), float(q['blon'][0])))
         elif u.path == '/api/trace':
             r = trace(q['key'][0], int(q['i0'][0]), int(q['i1'][0]))
             self._send(r or {}, 200 if r else 404)

--- a/tools/validate_graph.py
+++ b/tools/validate_graph.py
@@ -35,11 +35,23 @@ def check(graph, obs=None):
     # duplicate ids within each space
     for label, items in (('trail', graph.get('trails', [])), ('node', graph.get('nodes', [])),
                          ('segment', graph.get('segments', [])), ('feature', graph.get('features', []))):
-        seen = set()
+        seen, folded = set(), {}
         for it in items:
             if it['id'] in seen:
                 err(f"duplicate {label} id {it['id']!r}")
             seen.add(it['id'])
+            # Ids are case-sensitive, but a segment's geometry lives at geometry/<id>.json
+            # and case-insensitive filesystems collapse 0A and 0a onto one file, silently
+            # destroying the older line. That is a segment-only data loss, but the rule is
+            # enforced on every kind so the id space reads the same way everywhere and a
+            # graph stays portable rather than depending on where it was authored.
+            k = it['id'].lower()
+            if k in folded and folded[k] != it['id']:
+                err(f"{label} ids {folded[k]!r} and {it['id']!r} differ only in case"
+                    + (" — their geometry files collide on a case-insensitive filesystem"
+                       if label == 'segment' else
+                       " — ids must be unique regardless of case"))
+            folded[k] = it['id']
 
     # a retired id must not be back in circulation
     for rid, r in retired.items():
@@ -57,8 +69,14 @@ def check(graph, obs=None):
         for end in ('from', 'to'):
             if s[end] not in nodes:
                 err(f"segment {sid!r} {end} references unknown node {s[end]!r}")
+        # A leg that returns to its own junction is legitimate but rare -- a spur of tread
+        # that loops back rather than dead-ending, where no node belongs partway round
+        # because there is nothing to turn onto. Warn rather than reject, so it gets a
+        # human look without the graph having to lie about the ground.
         if s['from'] == s['to']:
-            err(f"segment {sid!r} starts and ends at the same node {s['from']!r}")
+            warn(f"segment {sid!r} ({s['name']!r}) starts and ends at node {s['from']!r} — "
+                 f"fine for tread that genuinely loops back, wrong if the far endpoint was "
+                 f"meant to be a different node")
         if s['miles'] <= 0:
             err(f"segment {sid!r} has non-positive length {s['miles']}")
         if not s.get('trails'):
@@ -105,12 +123,36 @@ def check(graph, obs=None):
                         seen.add(nb)
                         stack.append(nb)
             components.append(comp)
+        # A split is an error unless it has been declared. Almost every split is a missed
+        # junction; a genuine one — a trailhead reached only by water, say — is real
+        # geography and gets recorded in the graph rather than silencing the check.
+        declared = {frozenset(i['nodes']): i for i in graph.get('islands', [])}
+        matched = set()
         if len(components) > 1:
             components.sort(key=len, reverse=True)
-            err(f"network splits into {len(components)} disconnected components "
-                f"(largest {len(components[0])} nodes); a route cannot cross between them")
+            undeclared = []
             for c in components[1:]:
-                err(f"  stranded: {', '.join(sorted(nodes[n]['name'] for n in c))}")
+                key = frozenset(c)
+                if key in declared:
+                    matched.add(key)
+                    warn(f"island (declared {declared[key]['on']}): "
+                         f"{', '.join(sorted(nodes[n]['name'] for n in c))} — "
+                         f"{declared[key]['reason']}")
+                else:
+                    undeclared.append(c)
+            if undeclared:
+                err(f"network splits into {len(components)} components "
+                    f"(largest {len(components[0])} nodes), {len(undeclared)} of them "
+                    f"undeclared; a route cannot cross between them")
+                for c in undeclared:
+                    err(f"  stranded: {', '.join(sorted(nodes[n]['name'] for n in c))}")
+        for key, i in declared.items():
+            if key not in matched:
+                unknown = [n for n in key if n not in nodes]
+                err(f"islands entry dated {i['on']} does not match any isolated component"
+                    + (f" — unknown node(s) {', '.join(sorted(unknown))}" if unknown else
+                       " — those nodes are connected to the rest of the network, or the "
+                       "component has changed and needs re-reviewing"))
 
     # features
     for fid, f in features.items():


### PR DESCRIPTION
Three bugs found while curating the range. Each produced a plausible-looking segment with the wrong line underneath it, and none of them errored anywhere.

## Segments traced the long way round

`tracks_through()` returned only each track's *nearest* point to a junction, so on a loop or an out-and-back the two endpoints could land on different visits, and the sub-path between them ran most of the way about the loop — a 0.2 mi hop recorded as **30.3 mi**.

`passes_through()` now returns every visit, and a new `/api/arcs` pairs them as a cross product rather than a lookup, returning every arc shortest-first. Arcs within a band of the shortest are the same leg recorded on different trips, where length says nothing, so there the tightest snap still wins — the old behaviour, kept where it was right.

The form labels each arc with its length, and **draws the candidate on the map in orange before it is committed**, pulling it into view when it does not already fit. A leg running the wrong way is obvious as a line and invisible as a number.

Two related shapes this does *not* catch are documented rather than fixed, since both need judgement at the point of curation: a closed track's start/end seam hides one arc from index-interval enumeration, and a junction whose tread passes just outside the 40 m tolerance offers no arc at all.

## Case-only id collisions destroyed geometry

Ids are case-sensitive strings, but a segment's geometry lives at `geometry/<id>.json` and macOS is case-insensitive — so `0A` and `0a` were **one file**, and the second write silently ate the first segment's line. No error from the filesystem, none from the tool, and nothing visibly wrong until the map drew two segments on top of each other. It cost 14 segments, recovered only from a backup that happened to predate the collision.

Uniqueness is now checked case-folded in three places, because any one alone leaves a gap:

- `mint()` never issues a colliding code
- `write_state()` refuses to write a graph containing one, rather than destroying a line
- the validator reports it, so a graph authored on a case-sensitive filesystem still fails here

Two-character capacity drops from 3,844 to 1,296, still above the pessimistic ~850 bound. If that is ever approached the answer is three characters, not reclaiming case — an id space that is only safe on some filesystems is not safe.

## A real island failed a check written for a mistake

The connectivity check earns its keep: it caught a missed 0.08 mi connector between two trailhead nodes 118 m apart, which nothing else would have. But Fig Trailhead is reached by kayak across the Verde — its trip shares no ground with any other, and the far bank is 2.08 mi from the nearest node — so no walked route reaches it and none will without a new trip.

Rather than downgrade the check, `islands` declares such a component with its nodes, a date and the reason, the way `retired` tombstones an id. An undeclared split is still an error, and a declaration that stops matching its component errors too, so the exception is a reviewed act rather than a permanent hole.

## Also

A leg that returns to its own junction is now a warning rather than an error. Tread that loops back with nothing to turn onto partway is real, and putting a node midway to dodge it would contradict the schema's own reasoning about why features are not nodes.

`docs/trail-graph-schema.md` gains decisions 5 and 6, including the rule the roads raised: **a road is a segment only when it was walked.** An unwalked road has no source, so its geometry would have to be invented, and anything in the graph is clickable.

## Testing

- Every bug case verified to now default to the correct arc, with the long arcs still listed and labelled
- All 104 segments swept for shorter single-leg arcs; endpoint offsets and elevation reconciliation checked across the graph
- `islands` negative-tested: declaration removed, declaration no longer matching, stale entry, unknown node, and a new undeclared split alongside a declared one — all still error
- `schema/example/graph.json` still validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnyK2U1MGEJac1FDRJwioA