### PR TITLE
Define the condition observation schema (#17)

### DIFF
--- a/curation/observations.json
+++ b/curation/observations.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "observations": []
+}

--- a/docs/condition-observations.md
+++ b/docs/condition-observations.md
@@ -1,0 +1,176 @@
+# Condition observations
+
+Closes [#17](https://github.com/jacobemerick/mazatzalhiking/issues/17). Populated by
+[#18](https://github.com/jacobemerick/mazatzalhiking/issues/18); rendered by
+[#19](https://github.com/jacobemerick/mazatzalhiking/issues/19).
+
+- Contract: [`schema/observations.schema.json`](../schema/observations.schema.json)
+- Example instance: [`schema/example/observations.json`](../schema/example/observations.json)
+  (placeholder text, deliberately)
+- Real instance: [`curation/observations.json`](../curation/observations.json), empty
+  until #18
+- Validator: `./tools/validate_graph.py curation/graph.json` picks up the sibling
+  `observations.json` automatically
+
+**Decision: an observation is one dated, categorised, first-person note about one
+segment, junction, or feature, with photos hanging off it. It is hand-authored into a
+file the pipeline never touches, and it is the only way any condition text or photo
+reaches the site.**
+
+```json
+{
+  "target": "segment:0C",
+  "date": "2026-05-23",
+  "category": "brush",
+  "text": "…",
+  "source": "RS_SandySaddleTM12_231525.gpx",
+  "photos": [{ "file": "…jpg", "caption": "…" }]
+}
+```
+
+Four consumers read this record and nothing else: the builder popup, the GPX/KML
+export descriptions ([#21](https://github.com/jacobemerick/mazatzalhiking/issues/21)),
+the shared display component (#19), and the generated trail pages
+([#31](https://github.com/jacobemerick/mazatzalhiking/issues/31)). One record, so they
+cannot drift.
+
+---
+
+## Decisions
+
+### 1. A target names its kind, because the id spaces overlap
+
+**Decision: `target` is `<kind>:<id>`, kind being `segment`, `node`, or `feature`.**
+
+The graph schema gave each entity type its own id space, and the sketch of observations
+in that document used a bare id as the target. That sketch was wrong in practice, not
+just in theory: in the committed graph **82 of 84 node ids are also segment ids**, and
+49 of 49 trail ids are. A note targeting `4H` names a junction and a leg at once, and
+the old validator masked this by accepting an id found in *any* space.
+
+The prefix costs eight characters per record and removes the ambiguity entirely. The
+validator now resolves the id in the named space only, and points at `superseded_by`
+when the id is a retired segment, since a split is the one graph change that
+invalidates an observation and the tombstone says where the note should move.
+
+**Trails are not a target.** A trail-wide note ("the whole Barnhardt Trail was cleared
+in spring 2024") is real, but the surfaces that show conditions are all leg-shaped: the
+popup is on a leg, the export lists legs, the trail page is sectioned by leg. A trail
+note would either be repeated under every leg or shown nowhere, so it is written against
+the legs it applies to. The per-trail introduction paragraph in #31 is prose, not an
+observation, and is not this file's concern.
+
+### 2. The date is a full day, always
+
+**Decision: `date` is `YYYY-MM-DD`. No month-only dates, no "spring 2021".**
+
+Every observation comes from a walk, and every walk in this project has a date:
+[`tools/trips.csv`](../tools/trips.csv) carries one per recorded trip, and the
+HikeArizona trip reports #18 will draw on are dated too. So the strictness costs nothing
+for real observations, and what it prevents is worth having: a note whose date was
+guessed is a note whose age is a guess, and the age is the whole point. A 2016 note on a
+burn-scar leg and a note from last spring mean different things, which is why the date
+travels with the text on every surface and is never hidden behind "recently".
+
+The validator rejects a future date, which is the only mistake a full date can still make.
+
+### 3. One category per observation
+
+**Decision: `category` is required and single-valued, from a closed list.**
+
+The list, and what each means:
+
+| category | means |
+|---|---|
+| `brush` | overgrowth narrowing or hiding the tread |
+| `deadfall` | downed timber across it, the post-fire problem that keeps changing |
+| `tread` | the surface itself, washed out, sloughed, or rebuilt |
+| `route-finding` | where the way is hard to follow, including missing signs and cairns |
+| `water` | whether a source is running |
+| `access` | how you reach the ground at all: roads, gates, crossings, closures |
+
+`deadfall` is new since the graph document's sketch. Both fires that shaped this range
+(Willow 2004, Sunflower 2012) predate the corpus, so every recorded track is post-fire,
+and inside the scars the thing that changes between visits is deadfall and regrowth. They
+are different problems for a hiker, so they are different categories. The "unsigned
+junction" case from the graph document is `route-finding` on a node, and the Fig
+Trailhead kayak crossing is `access` on a node.
+
+Single-valued so that a surface can summarise a leg by its categories and pick an icon
+without parsing text. A note that genuinely covers two things becomes two observations
+with the same date, which is a small authoring cost and keeps the summaries honest.
+There is no catch-all category on purpose: if #18 meets a note that fits nothing here,
+the list grows by a reviewed edit to the schema, rather than `general` quietly absorbing
+everything.
+
+### 4. Text is plain, and only Jacob writes it
+
+**Decision: `text` is plain text with blank-line paragraphs. No markup, no links.**
+
+The same string is rendered into HTML on a page and in a popup, and into a GPX
+`<desc>` that a GPS unit shows as raw characters. Markdown would either need three
+renderers or show up as asterisks on a device in the field. Paragraph breaks are the one
+piece of structure every consumer can honour.
+
+The rule from the ticket is unchanged and now mechanically enforced as far as it can be:
+the validator refuses any text containing `PLACEHOLDER` outside `schema/example/`, so
+the illustrative records can never be validated as real ones. It cannot check
+authorship. Nothing can. That remains a rule about who edits the file.
+
+### 5. Photos hang off observations, and nowhere else
+
+**Decision: `photos` is an optional list on an observation; each entry is a filename
+and an optional caption. There is no photo entity, no gallery, and no photo without a
+dated note above it.**
+
+[#20](https://github.com/jacobemerick/mazatzalhiking/issues/20) decided that photos
+are context for conditions only. The natural consequence is that a photo's date and
+place are the observation's date and place, so the photo carries neither. Attaching it
+to the note rather than to the segment means it is shown with the words that explain
+it, and it ages with them: a 2016 photo of brush is under a 2016 note, and a 2026 note
+saying the brush is gone sits above both.
+
+`file` is a **basename only**. Where the files live and how they are served is the page
+generator's decision (#30) and may change; a reference that is just a name survives
+that, while a path would not. The narrowed photo inventory
+([#5](https://github.com/jacobemerick/mazatzalhiking/issues/5)) only has to place the
+photos that get attached here, not the whole library.
+
+The validator warns when one file is attached to two observations. Legitimate, perhaps,
+but usually a copy-paste, and one photo shows one dated condition.
+
+### 6. Provenance is recorded when it exists
+
+**Decision: optional `source`, the archive filename of the trip the note comes from.**
+
+Segments carry the tracks they were traced from because walked-it-myself provenance is
+the point of the project. An observation drawn from a recorded trip can carry the same
+link, and the date should match that trip's date in `trips.csv`. It is optional because a
+note can predate the corpus or come from a walk that was not recorded, and a true note
+without a file is better than a fabricated file. The validator does not cross-check it
+against `archive/` today; #18 may want that once the field is in use.
+
+### 7. Storage order is not display order
+
+**Decision: the file is an append-in-any-order list. Every consumer sorts newest-first
+per target, ties in file order.**
+
+Enforcing sort order in the file would make authoring a chore and gain nothing, since
+consumers have to group by target anyway. Newest-first is a display rule and lives in
+the display component (#19). An observation is never edited into a different claim:
+if conditions changed, that is a new observation with a new date, and the old one
+stays. Corrections to wording are edits; corrections to fact are new records.
+
+## What this does not decide
+
+- **Where photos are stored and served.** #30. The schema only guarantees the
+  reference is a bare name.
+- **Partial-leg targets.** "Brushy for the upper mile" is expressed in the text. A
+  fractional range on a segment (the `at` that features use) would be additive to this
+  schema if #18 turns out to need it, and nothing here precludes it.
+- **What counts as an observation worth writing.** #18. The schema accepts a one-line
+  note and a three-paragraph one equally; an absent note is correct, and an invented one
+  is not.
+- **How a split segment's observations migrate.** The tombstone says where the ground
+  went; moving the note onto the right half is a hand decision, and the validator
+  reports it rather than guessing.

--- a/docs/trail-graph-schema.md
+++ b/docs/trail-graph-schema.md
@@ -138,8 +138,10 @@ values, picked by how each leg is traversed. No re-derivation at runtime.
 
 ### 4. Conditions attach to any id, in their own file
 
-**Decision: an observation names a `target` — a segment, node, or feature id — plus a
-date and Jacob's text.**
+**Decision: an observation names a `target` — a segment, node, or feature — plus a
+date and Jacob's text.** The full contract is
+[`docs/condition-observations.md`](condition-observations.md) (#17); this section
+records only why observations are a separate file.
 
 Segments carry most of it ("the tread above the saddle is brushy"). But conditions are not
 always leg-shaped: a junction can be unsigned and easy to miss, and a spring can be dry.
@@ -271,8 +273,10 @@ at build time by projecting onto the segment. Storing the projection as truth wo
 it wrong the moment geometry is refined, whereas "Club Cabin is at this coordinate" stays
 true forever.
 
-**observation** (separate file) — `target` (any id), `date`, `text`, `category`
-(`brush` | `tread` | `route-finding` | `water` | `access`).
+**observation** (separate file) — `target` (`<kind>:<id>`, since id spaces overlap),
+`date`, `category`, `text`, optional `source` and `photos`. Contract in
+[`schema/observations.schema.json`](../schema/observations.schema.json), decisions in
+[`docs/condition-observations.md`](condition-observations.md).
 
 ## What this does not decide
 

--- a/schema/example/observations.json
+++ b/schema/example/observations.json
@@ -2,25 +2,29 @@
   "version": 1,
   "observations": [
     {
-      "target": "4H",
+      "target": "segment:4H",
       "date": "2017-09-01",
       "category": "brush",
-      "text": "PLACEHOLDER. Illustrative text only — see README.md. Real observation text is written by Jacob and by nobody else."
+      "text": "PLACEHOLDER. Illustrative text only — see README.md. Real observation text is written by Jacob and by nobody else.",
+      "source": "example_trip_2017.gpx",
+      "photos": [
+        { "file": "2017-09-01-placeholder.jpg", "caption": "PLACEHOLDER caption. A photo exists on the site only through an observation." }
+      ]
     },
     {
-      "target": "4H",
+      "target": "segment:4H",
       "date": "2016-03-05",
       "category": "route-finding",
-      "text": "PLACEHOLDER. Illustrative text only. Two observations on one segment, shown newest first, demonstrating that notes accumulate over time rather than being overwritten."
+      "text": "PLACEHOLDER. Illustrative text only. Two observations on one segment, shown newest first, demonstrating that notes accumulate over time rather than being overwritten.\n\nA second paragraph, separated by a blank line, which is the only structure the text carries."
     },
     {
-      "target": "8B",
+      "target": "node:8B",
       "date": "2016-03-05",
       "category": "route-finding",
-      "text": "PLACEHOLDER. An observation attached to a node rather than a segment — the case a segment-only model cannot express."
+      "text": "PLACEHOLDER. An observation attached to a node rather than a segment — the case a segment-only model cannot express. The kind prefix matters: node 8B and segment 8B would be different things."
     },
     {
-      "target": "f2",
+      "target": "feature:f2",
       "date": "2017-09-01",
       "category": "water",
       "text": "PLACEHOLDER. An observation attached to a feature. Whether a spring is running is the archetypal dated fact."

--- a/schema/observations.schema.json
+++ b/schema/observations.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mazatzalhiking.com/schema/observations.schema.json",
+  "title": "Mazatzal condition observations",
+  "description": "Dated, first-person notes about the state of a segment, junction, or feature, at curation/observations.json. Hand-authored by Jacob and never regenerated: this file is published advice about a real wilderness, and every word in it was written by someone who walked that ground on the date given. See docs/condition-observations.md.",
+  "type": "object",
+  "required": ["version", "observations"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 },
+    "observations": {
+      "description": "Storage order is not display order. Consumers sort newest first per target; the file may be appended to in any order.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/observation" }
+    }
+  },
+  "$defs": {
+    "observation": {
+      "type": "object",
+      "required": ["target", "date", "category", "text"],
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "description": "What the note is about, as '<kind>:<id>' where kind is segment, node, or feature and id is that entity's id in graph.json. The kind prefix is required because each entity type has its own id space and they overlap almost completely (82 of 84 node ids are also segment ids), so a bare id does not identify anything. Trails are not a valid target: a trail-wide condition is written against the legs it applies to.",
+          "type": "string",
+          "pattern": "^(segment|node|feature):[0-9A-Za-z]{2,4}$"
+        },
+        "date": {
+          "description": "The day the condition was seen, as YYYY-MM-DD. A full date, always: every observation comes from a walk, and every walk has a date (tools/trips.csv). The date is what makes the note meaningful and is always shown alongside the text.",
+          "type": "string",
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
+        },
+        "category": {
+          "description": "One per observation, so surfaces can summarise and pick an icon. A note that covers two things is two observations. brush: overgrowth narrowing or hiding the tread. deadfall: downed timber across it, the burn-scar problem. tread: the surface itself, washed out, sloughed, or rebuilt. route-finding: where the way is hard to follow, including missing signs and cairns. water: whether a source is running. access: how you get to the ground at all, roads, gates, crossings, closures.",
+          "enum": ["brush", "deadfall", "tread", "route-finding", "water", "access"]
+        },
+        "text": {
+          "description": "The observation, in the author's words, as plain text. Paragraphs are separated by a blank line; no markup, because the same text is rendered into HTML on pages and popups and into a GPX description that has neither. Never generated, never inferred, never summarised from someone else's report.",
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "description": "The recorded trip the note comes from, as its archive filename, matching segments[].sources[].file in graph.json. Optional, because a note can predate the corpus, but worth recording when it exists: it is the same walked-it-myself provenance the geometry carries.",
+          "type": "string",
+          "minLength": 1
+        },
+        "photos": {
+          "description": "Photos that show this condition, taken on this walk. A photo exists on the site only through an observation; there is no gallery and no photo without a dated note to sit under. Omit rather than leave empty.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["file"],
+            "additionalProperties": false,
+            "properties": {
+              "file": {
+                "description": "Basename only, no directory. Where photo files live and how they are served is the page generator's decision, not this schema's; the reference has to stay valid if that decision changes.",
+                "type": "string",
+                "pattern": "^[^/\\\\]+\\.(jpe?g|png|webp)$"
+              },
+              "caption": {
+                "description": "What the photo shows, if the observation text does not already say. Plain text.",
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/validate_graph.py
+++ b/tools/validate_graph.py
@@ -3,6 +3,8 @@
 
     ./tools/validate_graph.py schema/example/graph.json [observations.json]
 
+The observations file defaults to the sibling observations.json when one exists.
+
 Checks the invariants that matter for correctness rather than mere shape: that
 references resolve, that the network is actually connected, and that retired ids
 stay retired. Exits non-zero on any error, so a build can gate on it.
@@ -11,7 +13,8 @@ This is the seed of the validation #16 asks for, not its completion — #16 stil
 to check total network mileage against the corpus inventory and wire this into the
 build. Written against the stdlib so it runs anywhere with no install step.
 """
-import json, sys, os
+import json, sys, os, re, pathlib
+from datetime import date
 from collections import defaultdict
 
 errors, warnings = [], []
@@ -25,7 +28,7 @@ def warn(m):
     warnings.append(m)
 
 
-def check(graph, obs=None):
+def check(graph, obs=None, obs_path=None):
     trails = {t['id']: t for t in graph.get('trails', [])}
     nodes = {n['id']: n for n in graph.get('nodes', [])}
     segments = {s['id']: s for s in graph.get('segments', [])}
@@ -164,34 +167,94 @@ def check(graph, obs=None):
 
     # observations
     if obs is not None:
-        valid = set(segments) | set(nodes) | set(features)
-        for o in obs.get('observations', []):
-            if o['target'] not in valid:
-                err(f"observation dated {o.get('date')} targets unknown id {o['target']!r}"
-                    + (f" — that id is retired ({retired[o['target']]['reason']})"
-                       if o['target'] in retired else ""))
-            if not o.get('date'):
-                err(f"observation on {o['target']!r} has no date — the date is what makes "
-                    f"the note meaningful and must always travel with the text")
+        check_observations(obs, segments, nodes, features, retired, obs_path)
 
     return dict(trails=len(trails), nodes=len(nodes), segments=len(segments),
                 features=len(features), retired=len(retired),
+                observations=len(obs.get('observations', [])) if obs is not None else None,
                 miles=round(sum(s['miles'] for s in segments.values()), 1))
+
+
+OBS_CATEGORIES = ('brush', 'deadfall', 'tread', 'route-finding', 'water', 'access')
+OBS_TARGET = re.compile(r'^(segment|node|feature):([0-9A-Za-z]{2,4})$')
+OBS_DATE = re.compile(r'^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$')
+OBS_PHOTO = re.compile(r'^[^/\\\\]+\.(jpe?g|png|webp)$')
+
+
+def check_observations(obs, segments, nodes, features, retired, obs_path=None):
+    """The rules in schema/observations.schema.json, re-checked here because this
+    tool is stdlib-only and does not run a JSON Schema validator. The ones that
+    need the graph -- does the target exist, in the right id space -- can only
+    live here anyway."""
+    spaces = {'segment': segments, 'node': nodes, 'feature': features}
+    # Placeholder text is fine in schema/example, which exists to be invented. In a
+    # real instance it is fabricated trail advice under Jacob's name, so refuse it.
+    example = obs_path is not None and 'example' in pathlib.Path(obs_path).parts
+    photos_seen = {}
+    for i, o in enumerate(obs.get('observations', [])):
+        where = f"observation #{i} ({o.get('target')!r}, {o.get('date')!r})"
+        m = OBS_TARGET.match(str(o.get('target', '')))
+        if not m:
+            err(f"{where}: target must be '<kind>:<id>' with kind segment, node or "
+                f"feature -- a bare id is ambiguous because node and segment ids overlap, "
+                f"and a trail is not a target: write the note against its legs")
+        else:
+            kind, tid = m.groups()
+            if tid not in spaces[kind]:
+                err(f"{where}: no {kind} with id {tid!r}"
+                    + (f" -- that id is retired ({retired[tid]['reason']}); re-target the "
+                       f"note onto {', '.join(retired[tid].get('superseded_by', [])) or 'its successor'}"
+                       if kind == 'segment' and tid in retired else ""))
+        d = o.get('date')
+        if not d or not OBS_DATE.match(str(d)):
+            err(f"{where}: date must be a full YYYY-MM-DD -- the date is what makes the "
+                f"note meaningful and must always travel with the text")
+        elif str(d) > date.today().isoformat():
+            err(f"{where}: date is in the future")
+        if o.get('category') not in OBS_CATEGORIES:
+            err(f"{where}: category {o.get('category')!r} is not one of "
+                f"{', '.join(OBS_CATEGORIES)}")
+        text = o.get('text')
+        if not isinstance(text, str) or not text.strip():
+            err(f"{where}: empty text -- an observation with nothing to say should not exist")
+        elif 'PLACEHOLDER' in text and not example:
+            err(f"{where}: placeholder text in a real instance -- every word here is "
+                f"published as trail advice and must be Jacob's")
+        for k in o:
+            if k not in ('target', 'date', 'category', 'text', 'source', 'photos'):
+                err(f"{where}: unknown field {k!r}")
+        photos = o.get('photos')
+        if photos is not None:
+            if not isinstance(photos, list) or not photos:
+                err(f"{where}: photos must be a non-empty list, or omitted")
+            else:
+                for ph in photos:
+                    f = ph.get('file', '') if isinstance(ph, dict) else ''
+                    if not OBS_PHOTO.match(str(f)):
+                        err(f"{where}: photo file {f!r} must be a bare basename ending "
+                            f"in .jpg, .jpeg, .png or .webp")
+                    elif f in photos_seen:
+                        warn(f"{where}: photo {f!r} is also attached to "
+                             f"{photos_seen[f]} -- one photo shows one dated condition")
+                    else:
+                        photos_seen[f] = where
 
 
 def main():
     if len(sys.argv) < 2:
         sys.exit(__doc__)
     graph = json.load(open(sys.argv[1]))
-    obs = json.load(open(sys.argv[2])) if len(sys.argv) > 2 else None
-    if obs is None:
+    obs_path = sys.argv[2] if len(sys.argv) > 2 else None
+    if obs_path is None:
         sibling = os.path.join(os.path.dirname(sys.argv[1]), 'observations.json')
         if os.path.exists(sibling):
-            obs = json.load(open(sibling))
+            obs_path = sibling
+    obs = json.load(open(obs_path)) if obs_path else None
 
-    stats = check(graph, obs)
+    stats = check(graph, obs, obs_path)
     print(f"{stats['trails']} trails  {stats['nodes']} nodes  {stats['segments']} segments  "
-          f"{stats['features']} features  {stats['retired']} retired  {stats['miles']} mi")
+          f"{stats['features']} features  {stats['retired']} retired  {stats['miles']} mi"
+          + (f"  {stats['observations']} observations" if obs is not None else ""))
 
     for w in warnings:
         print(f"  warn  {w}")


### PR DESCRIPTION
Closes #17.

An observation is one dated, categorised, first-person note about one segment, junction, or feature, with photos hanging off it. It is hand-authored into `curation/observations.json`, which the pipeline never touches, and it is the only way condition text or a photo reaches the site.

**Decisions**, argued in `docs/condition-observations.md`:

1. **`target` is `<kind>:<id>`.** The sketch in the graph document used a bare id. In the committed graph 82 of 84 node ids are also segment ids, so a bare `4H` named a junction and a leg at once, and the old validator masked it by accepting an id from any space. Trails are not a target; a trail-wide note is written against its legs.
2. **`date` is a full day.** Every observation comes from a walk and every walk has a date, so strictness costs nothing and a guessed age is prevented.
3. **One `category`, closed list:** brush, deadfall, tread, route-finding, water, access. `deadfall` is new, for the burn scars. No catch-all.
4. **`text` is plain text**, blank-line paragraphs, because the same string goes into HTML and a GPX description.
5. **Photos hang off observations.** Optional list of `{file, caption}`, basename only so storage (#30) can change. No photo without a dated note above it, as #20 decided.
6. **Optional `source`**: the archive trip the note comes from, same provenance the geometry carries.
7. **Storage order is not display order.** Consumers sort newest-first per target.

**Validator** now resolves targets in the named id space, points at `superseded_by` when the target is a retired segment, checks date shape and future dates, category, photo shape and reuse, unknown fields, and refuses `PLACEHOLDER` text outside `schema/example/`. Tested against a 14-record file of deliberately broken observations: 12 errors and 1 warning, each for the intended reason. Both the example and the real graph still validate.

`curation/observations.json` is committed empty. #18 fills it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSvWxwZou8nBV712VovFQG